### PR TITLE
bugfix submarine with armor >2

### DIFF
--- a/src/GameServer.pas
+++ b/src/GameServer.pas
@@ -3867,6 +3867,11 @@ begin {>>>server}
                   if Cap[mcDefense] > 2 then
                     Cap[mcDefense] := 2;
                 end;
+                mcDefense:
+                begin
+                 if Cap[mcDefense] > 2 then
+                  Cap[mcSub] := 0;
+                end;  
                 mcSeaTrans:
                 begin
                   if ServerVersion[Player] >= $010103 then


### PR DESCRIPTION
Submarine should not has armor greater then 2.
[in vanilla] Its doable if you first check submarine feature in unit design panel and then increase armor.
